### PR TITLE
feat: Implement file input for numbers (Fixes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Number Sorter
 
-A simple command-line application that sorts numbers provided as arguments.
+A simple command-line application that sorts numbers provided as arguments or from a file.
 
 ## Installation
 
@@ -10,17 +10,43 @@ pip install -r requirements.txt
 
 ## Usage
 
-```bash
-python sort_numbers.py 5 2 8 1 9 3
-# Output: 1 2 3 5 8 9
+There are three ways to provide numbers to the sorter:
 
-# You can also pipe numbers through stdin
-echo "5 2 8 1 9 3" | python sort_numbers.py
-```
+1.  **As command-line arguments:**
+    ```bash
+    python sort_numbers.py 5 2 8 1 9 3
+    # Output: 1.0 2.0 3.0 5.0 8.0 9.0
+    ```
+
+2.  **From a file (one number per line):**
+    Create a file, for example `mynumbers.txt`:
+    ```
+    5
+    2.5
+    8
+    1
+    9.1
+    3
+    ```
+    Then run the script:
+    ```bash
+    python sort_numbers.py --file mynumbers.txt
+    # Or using the short flag:
+    # python sort_numbers.py -f mynumbers.txt
+    # Output: 1.0 2.5 3.0 5.0 8.0 9.1
+    ```
+
+3.  **Via standard input (stdin):**
+    ```bash
+    echo "5 2 8 1 9 3" | python sort_numbers.py
+    # Output: 1.0 2.0 3.0 5.0 8.0 9.0
+    ```
+    If no arguments or file are provided, the script will wait for input from stdin (press Ctrl-D to end input).
 
 ## Features
 
 - Accepts numbers as command-line arguments
+- Accepts numbers from a specified file (one number per line)
 - Supports input through stdin
 - Handles both integers and floating-point numbers
 - Provides sorted output in ascending order

--- a/sort_numbers.py
+++ b/sort_numbers.py
@@ -1,37 +1,63 @@
 #!/usr/bin/env python3
 
 import sys
+import argparse
 
-def get_numbers():
-    # If there are command line arguments, use those
-    if len(sys.argv) > 1:
-        return [float(arg) for arg in sys.argv[1:]]
-    
-    # Otherwise, read from stdin
+def read_numbers_from_file(filepath):
+    """Reads numbers from a file, one number per line."""
+    numbers = []
     try:
-        input_line = sys.stdin.readline().strip()
-        return [float(num) for num in input_line.split()]
-    except EOFError:
-        return []
+        with open(filepath, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if line: # Ensure line is not empty
+                    numbers.append(float(line))
+    except FileNotFoundError:
+        print(f"Error: File not found: {filepath}", file=sys.stderr)
+        sys.exit(1)
+    except ValueError:
+        print(f"Error: File contains non-numeric data: {filepath}", file=sys.stderr)
+        sys.exit(1)
+    return numbers
 
 def main():
+    parser = argparse.ArgumentParser(description="Sort numbers provided via arguments, a file, or stdin.")
+    parser.add_argument('numbers_cli', nargs='*', type=float, help="Numbers to sort, provided as arguments.")
+    parser.add_argument('-f', '--file', type=str, help="Path to a file containing numbers, one per line.")
+    
+    args = parser.parse_args()
+    
+    numbers = []
+
     try:
-        # Get numbers from either command line args or stdin
-        numbers = get_numbers()
+        if args.file:
+            numbers = read_numbers_from_file(args.file)
+        elif args.numbers_cli:
+            numbers = args.numbers_cli
+        else:
+            # Correctly indented block for stdin
+            print("No file or direct arguments provided. Reading from stdin (Ctrl-D to end):", file=sys.stderr)
+            input_lines = sys.stdin.readlines()
+            for line in input_lines:
+                stripped_line = line.strip()
+                if stripped_line: 
+                    try:
+                        numbers.extend([float(num) for num in stripped_line.split()])
+                    except ValueError:
+                        print(f"Error: Invalid input in stdin. Please provide valid numbers.", file=sys.stderr)
+                        sys.exit(1)
         
         if not numbers:
-            print("Error: No numbers provided. Please provide numbers as arguments or through stdin.")
+            print("Error: No numbers provided. Use arguments, --file option, or stdin.", file=sys.stderr)
             sys.exit(1)
         
-        # Sort the numbers
         sorted_numbers = sorted(numbers)
-        
-        # Print the sorted numbers
         print(" ".join(str(num) for num in sorted_numbers))
         
-    except ValueError as e:
-        print(f"Error: Invalid input. Please provide valid numbers.")
+    except ValueError: 
+        print(f"Error: Invalid input. Please provide valid numbers as arguments.", file=sys.stderr)
         sys.exit(1)
+    # FileNotFoundError and file-related ValueErrors are handled in read_numbers_from_file
 
 if __name__ == "__main__":
     main()

--- a/test_sorter.py
+++ b/test_sorter.py
@@ -1,0 +1,153 @@
+import unittest
+import subprocess
+import os
+import tempfile
+import sys
+
+# Path to the script to be tested
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), 'sort_numbers.py')
+
+class TestNumberSorter(unittest.TestCase):
+
+    def run_script(self, args, stdin_data=None):
+        """Helper function to run the sort_numbers.py script."""
+        command = [sys.executable, SCRIPT_PATH] + args
+        process = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        stdout, stderr = process.communicate(input=stdin_data)
+        return stdout.strip(), stderr.strip(), process.returncode
+
+    def test_cli_arguments(self):
+        """Test sorting numbers passed as command-line arguments."""
+        stdout, stderr, returncode = self.run_script(['5', '1', '4', '2', '3'])
+        self.assertEqual(stdout, "1.0 2.0 3.0 4.0 5.0")
+        self.assertEqual(stderr, "")
+        self.assertEqual(returncode, 0)
+
+    def test_cli_arguments_empty(self):
+        """Test with no CLI arguments, should read from stdin (or show prompt)."""
+        # This test is tricky because it expects stdin. 
+        # We'll test stdin explicitly. If no args and no file, it prompts for stdin.
+        # If stdin is also empty, it should error.
+        stdout, stderr, returncode = self.run_script([], stdin_data="") # Empty stdin
+        self.assertIn("Error: No numbers provided.", stderr)
+        self.assertEqual(stdout, "")
+        self.assertEqual(returncode, 1)
+
+    def test_stdin_input(self):
+        """Test sorting numbers passed via stdin."""
+        stdout, stderr, returncode = self.run_script([], stdin_data="5 1 4 2 3\n")
+        self.assertEqual(stdout, "1.0 2.0 3.0 4.0 5.0")
+        self.assertIn("No file or direct arguments provided. Reading from stdin", stderr) # Expect prompt
+        self.assertEqual(returncode, 0)
+
+    def test_stdin_input_multiple_lines(self):
+        """Test sorting numbers passed via stdin over multiple lines."""
+        stdout, stderr, returncode = self.run_script([], stdin_data="5 1\n4 2\n3\n")
+        self.assertEqual(stdout, "1.0 2.0 3.0 4.0 5.0")
+        self.assertIn("No file or direct arguments provided. Reading from stdin", stderr)
+        self.assertEqual(returncode, 0)
+        
+    def test_stdin_invalid_input(self):
+        """Test invalid input via stdin."""
+        stdout, stderr, returncode = self.run_script([], stdin_data="5 1 abc 2 3\n")
+        self.assertIn("Error: Invalid input in stdin.", stderr)
+        self.assertEqual(stdout, "")
+        self.assertEqual(returncode, 1)
+
+    def test_file_input(self):
+        """Test sorting numbers from a file."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as tmp_file:
+            tmp_file.write("5\n1\n4.0\n2\n3.5\n")
+            tmp_filepath = tmp_file.name
+        
+        try:
+            stdout, stderr, returncode = self.run_script(['--file', tmp_filepath])
+            self.assertEqual(stdout, "1.0 2.0 3.5 4.0 5.0")
+            self.assertEqual(stderr, "")
+            self.assertEqual(returncode, 0)
+        finally:
+            os.remove(tmp_filepath)
+
+    def test_file_input_empty_lines_and_spaces(self):
+        """Test sorting numbers from a file with empty lines and spaces."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as tmp_file:
+            tmp_file.write("5\n  \n1\n\n4.0\n 2 \n3.5\n") # Includes an empty line and a line with just spaces
+            tmp_filepath = tmp_file.name
+        
+        try:
+            stdout, stderr, returncode = self.run_script(['--file', tmp_filepath])
+            self.assertEqual(stdout, "1.0 2.0 3.5 4.0 5.0") # Sorted order
+            self.assertEqual(stderr, "")
+            self.assertEqual(returncode, 0)
+        finally:
+            os.remove(tmp_filepath)
+
+
+    def test_empty_file_input(self):
+        """Test with an empty file."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as tmp_file:
+            tmp_filepath = tmp_file.name
+            # File is empty
+        
+        try:
+            stdout, stderr, returncode = self.run_script(['--file', tmp_filepath])
+            self.assertIn("Error: No numbers provided.", stderr)
+            self.assertEqual(stdout, "")
+            self.assertEqual(returncode, 1)
+        finally:
+            os.remove(tmp_filepath)
+
+    def test_invalid_file_path(self):
+        """Test behavior with a non-existent file."""
+        non_existent_file = "non_existent_test_file.txt"
+        stdout, stderr, returncode = self.run_script(['--file', non_existent_file])
+        self.assertIn(f"Error: File not found: {non_existent_file}", stderr)
+        self.assertEqual(stdout, "")
+        self.assertEqual(returncode, 1)
+
+    def test_invalid_file_content(self):
+        """Test behavior with a file containing non-numeric data."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as tmp_file:
+            tmp_file.write("5\n1\nabc\n2\n3\n")
+            tmp_filepath = tmp_file.name
+        
+        try:
+            stdout, stderr, returncode = self.run_script(['--file', tmp_filepath])
+            self.assertIn(f"Error: File contains non-numeric data: {tmp_filepath}", stderr)
+            self.assertEqual(stdout, "")
+            self.assertEqual(returncode, 1)
+        finally:
+            os.remove(tmp_filepath)
+
+    def test_cli_invalid_input(self):
+        """Test invalid numeric input from CLI."""
+        stdout, stderr, returncode = self.run_script(['5', '1', 'abc', '2', '3'])
+        self.assertIn("usage: sort_numbers.py", stderr) # Argparse error
+        self.assertIn("invalid float value: 'abc'", stderr) # Argparse error
+        self.assertEqual(stdout, "")
+        self.assertEqual(returncode, 2) # Argparse exits with 2 for bad args
+
+    def test_priority_file_over_cli_args(self):
+        """Test that file input is prioritized over CLI arguments if both are given (argparse default)."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as tmp_file:
+            tmp_file.write("10\n20\n")
+            tmp_filepath = tmp_file.name
+        
+        try:
+            # The script logic explicitly prioritizes --file
+            stdout, stderr, returncode = self.run_script(['--file', tmp_filepath, '1', '2', '3'])
+            self.assertEqual(stdout, "10.0 20.0")
+            self.assertEqual(stderr, "")
+            self.assertEqual(returncode, 0)
+        finally:
+            os.remove(tmp_filepath)
+            
+    def test_cli_then_stdin_if_no_file(self):
+        """Test that CLI args are used if present, and stdin is not prompted."""
+        stdout, stderr, returncode = self.run_script(['30', '10'], stdin_data="1 2 3")
+        self.assertEqual(stdout, "10.0 30.0")
+        self.assertEqual(stderr, "") # No prompt for stdin
+        self.assertEqual(returncode, 0)
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
This pull request introduces the ability to specify a file containing numbers (one per line) to be sorted, using the --file or -f command-line option, addressing issue #1.

Key changes:
- Refactored argument parsing in `sort_numbers.py` to use `argparse`.
- Added a `read_numbers_from_file` function to handle file reading and error checking.
- Established input source prioritization: file input > CLI arguments > standard input.
- All error messages are now directed to `stderr`.
- Introduced a comprehensive test suite (`test_sorter.py`) using `unittest` to cover all input methods (file, CLI, stdin) and various error conditions. All tests are passing.
- Updated `README.md` to clearly document the new file input feature and provide usage examples.